### PR TITLE
Build instructions

### DIFF
--- a/build-linux.html
+++ b/build-linux.html
@@ -26,9 +26,15 @@
                     <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
                 </a>
 
-                <section id="contact">
-                    For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-                </section>
+                <nav>
+                    <ul class="navbar">
+                        <li class="navbar"><a href="index.html">Overview</a></li>
+                        <li class="navbar active"><a href="index.html#build">Build</a></li>
+                        <li class="navbar"><a href="gallery.html">Gallery</a></li>
+                        <li class="navbar"><a href="perf.html">Performance</a></li>
+                        <li class="navbar" style="float:right"><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
             </header>
         </div>
 

--- a/build-linux.html
+++ b/build-linux.html
@@ -46,8 +46,8 @@
 
                 <p>
                     On Linux, OpenSWR is built within Mesa using the standard autoconf package as described in Mesa's
-                    <a href="http://www.mesa3d.org/install.html">installation page</a>, with the addition of "swr" to the
-                    list of gallium drivers.
+                    <a href="http://www.mesa3d.org/install.html">installation page</a>, with the addition of
+                    <code>swr</code> to the list of gallium drivers.
                 </p>
                 <p>
                     The instructions below describe how to compile Mesa using the Mesa released tarballs.  Compiling

--- a/build-linux.html
+++ b/build-linux.html
@@ -2,155 +2,241 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
+    <head>
+        <meta charset='utf-8'>
+        <meta http-equiv="X-UA-Compatible" content="chrome=1">
+        <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
 
-    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+        <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-    <title>OpenSWR</title>
-  </head>
+        <title>OpenSWR</title>
+    </head>
 
-  <body>
+    <body>
 
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-          <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
+        <!-- HEADER -->
+        <div id="header_wrap" class="outer">
+            <header class="inner">
+                <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-          <h1 id="project_title">OpenSWR</h1>
-          <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <h1 id="project_title">OpenSWR</h1>
+                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
 
-            <section id="contact">
-                For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-            </section>
-        </header>
-    </div>
+                <section id="contact">
+                    For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
+                </section>
+            </header>
+        </div>
 
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-    <section id="main_content" class="inner">
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+            <section id="main_content" class="inner">
 
-<h2>Linux Build Instructions</h2>
-<p>
-  On Linux, OpenSWR is built using the standard autoconf package
-  as described <a href="http://www.mesa3d.org/install.html">here</a>,
-  with the addition of "swr" to the list of gallium drivers.
-  Mesa requires some additional packages to build.  Please follow the Mesa
-  instructions and make sure you install them.
-  One of the major Mesa requirements is LLVM, but with some additional
-  flags required.
-<p>
-  The instructions below describe how to compile Mesa using the
-  Mesa released tarballs.
-  Compiling directly from the git repository is more complicated
-  and is beyond the scope of these instructions.
-  If you want to compile from the git repository and you have problems,
-  please contact us directly.
-<p>
-<h5>Instructions</h5>
-<li>
-  Download and unpack mesa.
-  Please follow the instructions in
-  <a href=http://www.mesa3d.org/download.html>
-    http://www.mesa3d.org/download.html
-  </a>
-<li>
-  cd into the directory you just extracted. (the root of the mesa distribution)
-<li>
-  Optional: If you don't have llvm installed,
-  follow the steps below to install llvm,
-  after you've downloaded it from the
-  <a href="http://www.llvm.org">
-    llvm website
-  </a>.
-  Please complete the <code>make</code> command
-  with the correct <code>-j</code> parameter for your system
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  mkdir llvm
-  cd llvm
-  tar xfJ /path/to/llvm-x.y.z.src.tar.xz
-  mkdir build root
-  cd build
-  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DBUILD_SHARED_LIBS=1 -DLLVM_ENABLE_RTTI=1 -DCMAKE_INSTALL_PREFIX=$PWD/../root  ../llvm-x.y.z.src
-  make -j10
-  make install
-  cd ..
-  # Allow the mesa build to locate llvm
-  export PATH=$PATH:$PWD/root/bin
-  export LD_LIBRARY_PATH=$PWD/root/lib
-  cd ..
-</code>
-</pre>
+                <h2>Linux Build Instructions</h2>
 
-<li>
-  Configure the mesa build with OpenSWR
+                <p>
+                    On Linux, OpenSWR is built within Mesa using the standard autoconf package as described in Mesa's
+                    <a href="http://www.mesa3d.org/install.html">installation page</a>, with the addition of "swr" to the
+                    list of gallium drivers.
+                </p>
+                <p>
+                    The instructions below describe how to compile Mesa using the Mesa released tarballs.  Compiling
+                    directly from the git repository is more complex and is beyond the scope of these instructions.  If
+                    you want to compile from the git repository and you run into issues, please contact us directly.
+                </p>
 
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  ../configure --disable-dri --disable-egl --disable-gbm --with-gallium-drivers=swrast,swr --with-platforms=x11
-</code>
-</pre>
+                <ol class="toc">
+                    <li class="toc"><a href="#setup">Setup</a>
+                        <ol class="toc">
+                            <li class="toc"><a href="#building-llvm">Building and Installing LLVM</a></li>
+                        </ol>
+                    </li>
+                    <li class="toc"><a href="#building-openswr">Building Mesa with OpenSWR</a></li>
+                    <li class="toc"><a href="#using-openswr">Using Mesa with OpenSWR</a></li>
+                </ol>
 
-If you have VL in your system, you will need to also pass the following flags:
+                <a name="setup"><h3>Setup</h3></a>
 
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  --disable-xvmc --disable-vdpau --disable-omx --disable-va
-</code>
-</pre>
+                <p>
+                    Mesa requires some dependencies to build:
+                </p>
 
-If you want to compile OSMesa, please add the following flags:
+                <ul>
+                    <li><code>libtool-bin</code></li>
+                    <li><code>autoconf</code></li>
+                    <li><code>python-pip</code></li>
+                    <li><code>libx11-dev</code></li>
+                    <li><code>libxext-dev</code></li>
+                    <li><code>x11proto-core-dev</code></li>
+                    <li><code>x11proto-gl-dev</code></li>
+                    <li><code>libglew-dev</code></li>
+                    <li><code>freeglut3-dev</code></li>
+                    <li><code>bison</code></li>
+                    <li><code>flex</code></li>
+                </ul>
 
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  --enable-gallium-osmesa
-</code>
-</pre>
+                <p>
+                as well as the following two Python modules installed via <code>pip</code>:
+                </p>
+                <ul>
+                    <li><code>mako</code></li>
+                    <li><code>lxml</code></li>
+                </ul>
 
-By default, the build builds for AVX and AVX2 targets.  If you want to
-also compile for Skylake and/or Knight's Landing architectures (AVX512),
-please add the following flags.  Make sure your compiler supports the
-necessery compiler flags to compile for the specified architectures.
+                <p>
+                Please
+                make sure you install them prior to building.
+                </p>
 
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  --with-swr-archs=avx,avx2,skx,knl
-</code>
-</pre>
+                <a name="building-llvm"><h4>Building and Installing LLVM</h4></a>
+                <p>
+                One of the major Mesa requirements is LLVM, but with some additional
+                flags required at compile time. If you do not already have LLVM, you will need to install it first.
+                LLVM source is available as tarball on their <a href="http://releases.llvm.org/">release download page</a>.
+                Once downloaded, use the following steps to build and install LLVM. In this example we are installing them locally.
+                </p>
+                <pre>
+$ pwd
+/home/openswr/llvm
+$ ls
+llvm-x.y.z.src.tar.xz
+$ tar xJf llvm-x.y.z.src.tar.xz
+$ mkdir build
+$ cd build
+$ cmake -G "Unix Makefiles"
+        -D CMAKE_BUILD_TYPE=Release \
+        -D LLVM_TARGETS_TO_BUILD=X86 \
+        -D BUILD_SHARED_LIBS=1 \
+        -D LLVM_ENABLE_RTTI=1 \
+        -D CMAKE_INSTALL_PREFIX=/home/openswr/.local/ \
+        ../llvm-x.y.z.src
+$ make -j `nproc`
+$ make install
+                </pre>
 
-<li> Build mesa as follows.  As with the llvm build, pass in the correct <code>-j</code> parameter to <code>make</code> for your system
 
-<pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  make -j10
-</code>
-</pre>
+                <a name="building-openswr"><h3>Building Mesa with OpenSWR</h3></a>
 
-</li>
+                <p>
+                Download a Mesa source distribution from Mesa's <a href="http://www.mesa3d.org/download.html">download page</a>.
+                We recommend the latest non-release-candidate version for the best compatibility.
+                </p>
 
-<p>
-  The resulting libraries are in the lib/gallium directory.  Also, you'll
-  have to set the <em>GALLIUM_DRIVER=swr</em> environment variable for
-  mesa to use the SWR driver.  If not specified, the default mesa
-  <em>llvmpipe</em> driver will be used.
+                <p>
+                Once downloaded, use the following steps to build Mesa with OpenSWR.
 
-<p>
-  Please feel free to modify the above instructions to fit your needs.
+                <pre>
+$ pwd
+/home/openswr/mesa
+$ ls
+mesa-x.y.z.tar.gz
+$ tar xf mesa-x.y.z.tar.gz
+$ cd mesa-x.y.z
+$ mkdir build
+$ cd build
+                </pre>
 
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
-		<br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
-		<br>&copy;2009-2018 Intel Corporation
-		<br><a href="https://www.intel.com/privacy">Privacy</a></p>
-      </footer>
-    </div>
+                <p>
+                Now we can configure Mesa with OpenSWR - note the addition of <code>swr</code> as a gallium driver.
+                In this example, we are installing Mesa locally.
+                </p>
 
-    
+                <pre>
+$ ../configure --disable-dri \
+               --disable-egl \
+               --disable-gbm \
+               --with-gallium-drivers=swrast,swr \
+               --with-platforms=x11 \
+               --prefix=/home/openswr/.local
+                </pre>
 
-  </body>
+                <p>
+                If you run into problems due to VL on your system, add the following flags to the above <code>configure</code> call:
+                </p>
+
+                <pre>
+--disable-xvmc --disable-vdpau --disable-omx --disable-va
+                </pre>
+
+                <p>
+                If you also want to compile OSMesa (off-screen rendering support), please add the following flag:
+                </p>
+
+                <pre>
+--enable-gallium-osmesa
+                </pre>
+
+                <p>
+                By default, the build will compile with support for AVX and AVX2 targets.  If you want to
+                also compile for Skylake and/or Knight's Landing architectures (AVX512),
+                please add the following flag. Make sure your compiler supports the
+                necessary compiler flags to compile for the specified architectures.
+                </p>
+
+                <pre>
+--with-swr-archs=avx,avx2,skx,knl
+                </pre>
+
+                <p>
+                After you have the appropriate <code>configure</code> command for your system, you can build and install with
+                <code>make</code>
+                </p>
+
+                <pre>
+$ make -j `nproc`
+$ make install
+                </pre>
+
+                <p>
+                Once installed, you will see <code>libGL.so</code>, <code>libOSMesa.so</code>, and <code>libSWR&lt;arch&gt;.so</code>
+                (for each architecture selected) in <code>lib/gallium/</code> in your build directory as well as in <code>lib/</code> in
+                your installation directory.
+                </p>
+
+                <a name="using-openswr"><h3>Using Mesa with OpenSWR</h3></a>
+
+                <p>
+                If you installed Mesa with OpenSWR to a local directory as in the examples above, it should already be usable by
+                applications. If you installed elsewhere, you will need to include the path in your <code>LD_LIBRARY_PATH</code>
+                environment variable. Make sure you specifically add the <code>lib</code> or <code>lib/gallium</code> directory to
+                <code>LD_LIBRARY_PATH</code>.
+                </p>
+
+                <pre>
+$ export LD_LIBRARY_PATH=/some/path/to/mesa/lib:$LD_LIBRARY_PATH
+                </pre>
+
+                <p>
+                Now any application seeking GL will use the Mesa installation. To enable the OpenSWR driver, you need to specify it with
+                the <code>GALLIUM_DRIVER</code> environment variable:
+                </p>
+
+                <pre>
+$ export GALLIUM_DRIVER=swr
+                </pre>
+
+                <p>
+                You should see a message printed to the terminal when running a GL application when OpenSWR is set as the gallium
+                driver. For example:
+                </p>
+
+                <pre>
+$ glxgears
+SWR detected AVX2 instruction support (using: libswrAVX2.so).
+                </pre>
+                <br>
+
+                <!-- FOOTER  -->
+                <div id="footer_wrap" class="outer">
+                    <footer class="inner">
+                        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
+                        <br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
+                        <br>&copy;2009-2018 Intel Corporation
+                        <br><a href="https://www.intel.com/privacy">Privacy</a></p>
+                    </footer>
+                </div>
+
+
+
+    </body>
 </html>

--- a/build-linux.html
+++ b/build-linux.html
@@ -94,8 +94,9 @@
                 </ul>
 
                 <p>
-                Please
-                make sure you install them prior to building.
+                Please make sure you install them prior to building. Refer to Mesa's
+                <a href="https://www.mesa3d.org/install.html">installation page</a> for more information on its
+                requirements.
                 </p>
 
                 <a name="building-llvm"><h4>Building and Installing LLVM</h4></a>

--- a/build-linux.html
+++ b/build-linux.html
@@ -19,8 +19,12 @@
             <header class="inner">
                 <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-                <h1 id="project_title">OpenSWR</h1>
-                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <a href="index.html">
+                    <h1 id="project_title">OpenSWR</h1>
+                </a>
+                <a href="index.html">
+                    <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                </a>
 
                 <section id="contact">
                     For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.

--- a/build-windows.html
+++ b/build-windows.html
@@ -2,47 +2,47 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
+    <head>
+        <meta charset='utf-8'>
+        <meta http-equiv="X-UA-Compatible" content="chrome=1">
+        <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
 
-    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+        <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-    <title>OpenSWR</title>
-  </head>
+        <title>OpenSWR</title>
+    </head>
 
-  <body>
+    <body>
 
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-          <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
+        <!-- HEADER -->
+        <div id="header_wrap" class="outer">
+            <header class="inner">
+                <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-          <h1 id="project_title">OpenSWR</h1>
-          <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <h1 id="project_title">OpenSWR</h1>
+                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
 
-            <section id="contact">
-                For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-            </section>
-        </header>
-    </div>
+                <section id="contact">
+                    For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
+                </section>
+            </header>
+        </div>
 
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-    <section id="main_content" class="inner">
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+            <section id="main_content" class="inner">
 
-      <h2>Windows Build Instructions</h2>
+                <h2>Windows Build Instructions</h2>
 
-      <p>
-On Windows, OpenSWR is built using the SCons package as described in Mesa's
-<a href="http://www.mesa3d.org/install.html">installation page</a>.
-OpenSWR also requires LLVM versions greater than 3.9.0 to build.
-      </p>
+                <p>
+                    On Windows, OpenSWR is built using the SCons package as described in Mesa's
+                    <a href="http://www.mesa3d.org/install.html">installation page</a>. OpenSWR also requires LLVM
+                    versions greater than 3.9.0 to build.
+                </p>
 
-      <p>
-The instructions below describe how to build Mesa with OpenSWR support for Windows.
-      </p>
+                <p>
+                    The instructions below describe how to build Mesa with OpenSWR support for Windows.
+                </p>
 
                 <ol class="toc">
                     <li class="toc"><a href="#setup">Setup</a>
@@ -54,50 +54,48 @@ The instructions below describe how to build Mesa with OpenSWR support for Windo
                     <li class="toc"><a href="#using-openswr">Using Mesa with OpenSWR</a></li>
                 </ol>
 
-                    <a name="setup"><h3>Setup</h3></a>
+                <a name="setup"><h3>Setup</h3></a>
 
-                    <p>
+                <p>
                     Mesa with OpenSWR requires the SCons package to build and install. SCons is available to download as
                     an executable installer on SCons' <a href="https://scons.org/pages/download.html">download page</a>.
                     The latest version should be fine.
-                    </p>
+                </p>
 
-                    <p>
+                <p>
                     If you don't already have LLVM installed, you will need to install it first. LLVM requires CMake to
-                    build and install. CMake is available for Windows as an executable installer on CMake's <a
-                                                         href="https://cmake.org/download/">download page</a>.  The
-                                                     latest version should be fine.
-                    </p>
+                    build and install. CMake is available for Windows as an executable installer on CMake's
+                    <a href="https://cmake.org/download/">download page</a>. The latest version should be fine.
+                </p>
 
-                    <p>
+                <p>
                     You will need a utility that can open and decompress <code>tar.gz</code> and/or <code>tar.xz</code>
-                    files. An easy-to-use (and free) graphical option for Windows is 7-zip, available on 7-zip's <a
-                                                         href="https://www.7-zip.org/download.html">download page</a>.
-                    </p>
+                    files. An easy-to-use (and free) graphical option for Windows is 7-zip, available on 7-zip's
+                    <a href="https://www.7-zip.org/download.html">download page</a>.
+                </p>
 
-                    <a name="building-llvm"><h4>Build and Install LLVM</h4></a>
+                <a name="building-llvm"><h4>Build and Install LLVM</h4></a>
 
-<p>
-Mesa with OpenSWR relies on LLVM, so you will need to build and install it first if you do not already have it.
-Please refer to the LLVM Windows build instructions with Visual Studio
-for a general overview, located
-<a href="http://llvm.org/docs/GettingStartedVS.html">here</a>.
-</p>
+                <p>
+                    Mesa with OpenSWR relies on LLVM, so you will need to build and install it first if you do not
+                    already have it.  Please refer to the LLVM Windows build instructions with Visual Studio for a
+                    general overview, located <a href="http://llvm.org/docs/GettingStartedVS.html">here</a>.
+                </p>
 
-<p>
-Once downloaded and decompressed, create a build directory to contain the built LLVM distribution.
-In this example, we build both the release and debug version of LLVM, though you can choose to only have one or the
-other.
-</p>
+                <p>
+                    Once downloaded and decompressed, create a build directory to contain the built LLVM distribution.
+                    In this example, we build both the release and debug version of LLVM, though you can choose to only
+                    have one or the other.
+                </p>
 
-<p>
-Suppose we have LLVM extracted to <code>C:\LLVM\src</code> with build directories <code>C:\LLVM\build-release</code> and
-<code>C:\LLVM\build-debug</code>. We will install to <code>C:\LLVM\install-release</code> and
-<code>C:\LLVM\install-debug</code>, respectively.
-Use <code>cmake</code> to generate MSVC <code>.sln</code> files, as follows:
-</p>
+                <p>
+                    Suppose we have LLVM extracted to <code>C:\LLVM\src</code> with build directories
+                    <code>C:\LLVM\build-release</code> and <code>C:\LLVM\build-debug</code>. We will install to
+                    <code>C:\LLVM\install-release</code> and <code>C:\LLVM\install-debug</code>, respectively. Use
+                    <code>cmake</code> to generate MSVC <code>.sln</code> files, as follows:
+                </p>
 
-<pre>
+                <pre>
 cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       -DLLVM_TARGETS_TO_BUILD=X86 `
       -DLLVM_ENABLE_RTTI=1 `
@@ -106,27 +104,25 @@ cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       -DLLVM_ENABLE_TERMINFO=OFF `
       -DCMAKE_INSTALL_PREFIX=C:\LLVM\install `
       C:\LLVM\src
-</pre>
+                </pre>
 
-<p>
-Note that, in theory, you only need to use one of <code>LLVM_USE_CRT_DEBUG</code>
-    or <code>LLVM_USE_CRT_RELEASE</code>, depending on whether you are building Debug
-  or Release, but it doesn't hurt to always include both in the cmake line.
-</p>
+                <p>
+                    Note that, in theory, you only need to use one of <code>LLVM_USE_CRT_DEBUG</code> or
+                    <code>LLVM_USE_CRT_RELEASE</code>, depending on whether you are building Debug or Release, but it
+                    doesn't hurt to always include both in the cmake line.
+                </p>
 
-<p>
-  The Mesa Windows SCons build has the peculiarity that you cannot
-  mix debug and release versions of libs (see link error LNK2038).
-  If you are planning of building both version of Mesa,
-  you should also build both versions of LLVM.
-  Below, I am assuming that we are building both.
-</p>
+                <p>
+                    The Mesa Windows SCons build has the peculiarity that you cannot mix debug and release versions of
+                    libs (see link error LNK2038). If you are planning of building both version of Mesa, you should
+                    also build both versions of LLVM. Below, I am assuming that we are building both.
+                </p>
 
-<p>
-  Build both flavors of LLVM as shown below. The release version:
-</p>
+                <p>
+                    Build both flavors of LLVM as shown below. The release version:
+                </p>
 
-<pre>
+                <pre>
 cd C:\LLVM\build-release
 cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       -DLLVM_TARGETS_TO_BUILD=X86 `
@@ -138,13 +134,13 @@ cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       C:\LLVM\src
 cmake --build . --config Release
 cmake --build . --config Release --target install
-</pre>
+                </pre>
 
-<p>
-and the debug version:
-</p>
+                <p>
+                    and the debug version:
+                </p>
 
-<pre>
+                <pre>
 cd C:\LLVM\build-debug
 cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       -DLLVM_TARGETS_TO_BUILD=X86 `
@@ -156,112 +152,112 @@ cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
       C:\LLVM\src
 cmake --build . --config Debug
 cmake --build . --config Debug --target install
-</pre>
+                </pre>
 
-<a name="building-openswr"><h3>Build Mesa with OpenSWR</h3></a>
+                <a name="building-openswr"><h3>Build Mesa with OpenSWR</h3></a>
 
-<p>
-First, clone the mesa repo. Full instructions are available on Mesa's <a
-   href="https://www.mesa3d.org/repository.html">repository page</a>. In this case, you can simply clone the read-only
-   repository.
-   </p>
+                <p>
+                    First, clone the mesa repo. Full instructions are available on Mesa's
+                    <a href="https://www.mesa3d.org/repository.html">repository page</a>. In this case, you can simply
+                    clone the read-only repository.
+                </p>
 
-   <pre>
-   git clone git://anongit.freedesktop.org/git/mesa/mesa
-   </pre>
+                <pre>
+git clone git://anongit.freedesktop.org/git/mesa/mesa
+                </pre>
 
-<p>
-When building Mesa with OpenSWR, you must specify where LLVM is installed. In doing this, we can also specify which
-type of build we will do. For a debug Mesa build, link to the debug LLVM installation. Similarly, use a release LLVM for
-building release Mesa. For release builds:
+                <p>
+                    When building Mesa with OpenSWR, you must specify where LLVM is installed. In doing this, we can
+                    also specify which type of build we will do. For a debug Mesa build, link to the debug LLVM
+                    installation.  Similarly, use a release LLVM for building release Mesa. For release builds:
+                </p>
 
-<pre>
-  set LLVM=C:\LLVM\install-release
-  scons swr=1 libgl-gdi build=release
-</pre>
+                <pre>
+set LLVM=C:\LLVM\install-release
+scons swr=1 libgl-gdi build=release
+                </pre>
 
-and for debug builds:
+                <p>
+                    and for debug builds:
+                </p>
 
-<pre>
-  set LLVM=C:\LLVM\install-debug
-  scons swr=1 libgl-gdi
-</pre>
+                <pre>
+set LLVM=C:\LLVM\install-debug
+scons swr=1 libgl-gdi
+                </pre>
 
-<p>
-  Note that you have to modify the LLVM environment variable between
-  debug and release builds.
-</p>
+                <p>
+                    Note that you have to modify the LLVM environment variable between
+                    debug and release builds.
+                </p>
 
-<p>
-If you want to compile OSMesa (for off-screen rendering support), simply add <code>osmesa</code> to SCons. For example:
-</p>
+                <p>
+                    If you want to compile OSMesa (for off-screen rendering support), simply add <code>osmesa</code> to
+                    SCons. For example:
+                </p>
 
-<pre>
-  set LLVM=C:\LLVM\install-release
-  scons swr=1 libgl-gdi osmesa build=release
-</pre>
+                <pre>
+set LLVM=C:\LLVM\install-release
+scons swr=1 libgl-gdi osmesa build=release
+                </pre>
 
+                <a name="using-openswr"><h3>Using Mesa with OpenSWR</h3></a>
 
-    <a name="using-openswr"><h3>Using Mesa with OpenSWR</h3></a>
+                <p>
+                    The build results in three DLL files:
+                    <ul>
+                        <li><code>opengl32.dll</code></li>
+                        <li><code>swrAVX.dll</code></li>
+                        <li><code>swrAVX2.dll</code></li>
+                    </ul>
+                    <code>opengl32.dll</code> is located in <code>build\windows-x86_64\gallium\targets\libgl-gdi</code>,
+                    and the SWR libraries are located in <code>build\windows-x86_64\gallium\drivers\swr</code>. To make
+                    these libraries usable across the system, first make a backup of
+                    <code>C:\Windows\system32\opengl32.dll</code>, then place the above DLLs in
+                    <code>C:\Windows\system32</code>.  If you plan to just run simple command line tests, you can simply
+                    place them in your current directory.
+                </p>
 
-<p>
-  The build results in three DLL files:
-  <ul>
-      <li><code>opengl32.dll</code></li>
-      <li><code>swrAVX.dll</code></li>
-      <li><code>swrAVX2.dll</code></li>
-  </ul>
-  <code>opengl32.dll</code> is located in
-  <code>build\windows-x86_64\gallium\targets\libgl-gdi</code>,
-  and the SWR libraries are located in
-  <code>build\windows-x86_64\gallium\drivers\swr</code>.
-  To make these libraries usable across the system, first make a backup of
-  <code>C:\Windows\system32\opengl32.dll</code>, then place the above DLLs in
-  <code>C:\Windows\system32</code>.
-  If you plan to just run simple command line tests, you can simply place them in your current directory.
-</p>
+                <p>
+                    If you built with OSMesa, the libraries will be found under the
+                    <code>build\windows-x86_64\gallium\targets\osmesa</code> directory. These can also be copied to
+                    <code>C:\Windows\system32</code>.
+                </p>
 
-  <p>
-If you built with OSMesa, the libraries will be found under the
-<code>build\windows-x86_64\gallium\targets\osmesa</code>
-directory. These can also be copied to 
-  <code>C:\Windows\system32</code>.
-  </p>
+                <p>
+                    To use Mesa with OpenSWR, you will need to set OpenSWR as the gallium driver to use with the
+                    <code>GALLIUM_DRIVER</code> environment variable:
+                </p>
 
-<p>
-To use Mesa with OpenSWR, you will need to set OpenSWR as the gallium driver to use with the <code>GALLIUM_DRIVER</code>
-environment variable:
-
-<pre>
+                <pre>
 set GALLIUM_DRIVER=swr
-</pre>
+                </pre>
 
-<p>
-Without this environmental variable set, the default Mesa <code>llvmpipe</code> driver will be used.
-</p>
+                <p>
+                    Without this environmental variable set, the default Mesa <code>llvmpipe</code> driver will be used.
+                </p>
 
-<p>
-When running with OpenSWR, you should see a message printed to the terminal stating that it found the appropriate
-architecture on your system:
-</p>
+                <p>
+                    When running with OpenSWR, you should see a message printed to the terminal stating that it found
+                    the appropriate architecture on your system:
+                </p>
 
-<pre>
+                <pre>
 SWR detected AVX2 instruction support (using: libswrAVX2.so).
-</pre>
-<br>
+                </pre>
+                <br>
+
+                <!-- FOOTER  -->
+                <div id="footer_wrap" class="outer">
+                    <footer class="inner">
+                        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
+                        <br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
+                        <br>&copy;2009-2018 Intel Corporation
+                        <br><a href="https://www.intel.com/privacy">Privacy</a></p>
+                    </footer>
+                </div>
 
 
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
-		<br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
-		<br>&copy;2009-2018 Intel Corporation
-		<br><a href="https://www.intel.com/privacy">Privacy</a></p>
-      </footer>
-    </div>
 
-    
-
-  </body>
+    </body>
 </html>

--- a/build-windows.html
+++ b/build-windows.html
@@ -19,8 +19,12 @@
             <header class="inner">
                 <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-                <h1 id="project_title">OpenSWR</h1>
-                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <a href="index.html">
+                    <h1 id="project_title">OpenSWR</h1>
+                </a>
+                <a href="index.html">
+                    <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                </a>
 
                 <section id="contact">
                     For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
@@ -96,13 +100,13 @@
                 </p>
 
                 <pre>
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
-      -DLLVM_TARGETS_TO_BUILD=X86 `
-      -DLLVM_ENABLE_RTTI=1 `
-      -DLLVM_USE_CRT_DEBUG=MTd `
-      -DLLVM_USE_CRT_RELEASE=MT `
-      -DLLVM_ENABLE_TERMINFO=OFF `
-      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install `
+cmake -D CMAKE_GENERATOR_PLATFORM=x64 `
+      -D LLVM_TARGETS_TO_BUILD=X86 `
+      -D LLVM_ENABLE_RTTI=1 `
+      -D LLVM_USE_CRT_DEBUG=MTd `
+      -D LLVM_USE_CRT_RELEASE=MT `
+      -D LLVM_ENABLE_TERMINFO=OFF `
+      -D CMAKE_INSTALL_PREFIX=C:\LLVM\install `
       C:\LLVM\src
                 </pre>
 
@@ -124,13 +128,13 @@ cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
 
                 <pre>
 cd C:\LLVM\build-release
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
-      -DLLVM_TARGETS_TO_BUILD=X86 `
-      -DLLVM_ENABLE_RTTI=1 `
-      -DLLVM_USE_CRT_DEBUG=MTd `
-      -DLLVM_USE_CRT_RELEASE=MT `
-      -DLLVM_ENABLE_TERMINFO=OFF `
-      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install-release `
+cmake -D CMAKE_GENERATOR_PLATFORM=x64 `
+      -D LLVM_TARGETS_TO_BUILD=X86 `
+      -D LLVM_ENABLE_RTTI=1 `
+      -D LLVM_USE_CRT_DEBUG=MTd `
+      -D LLVM_USE_CRT_RELEASE=MT `
+      -D LLVM_ENABLE_TERMINFO=OFF `
+      -D CMAKE_INSTALL_PREFIX=C:\LLVM\install-release `
       C:\LLVM\src
 cmake --build . --config Release
 cmake --build . --config Release --target install
@@ -142,13 +146,13 @@ cmake --build . --config Release --target install
 
                 <pre>
 cd C:\LLVM\build-debug
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
-      -DLLVM_TARGETS_TO_BUILD=X86 `
-      -DLLVM_ENABLE_RTTI=1 `
-      -DLLVM_USE_CRT_DEBUG=MTd `
-      -DLLVM_USE_CRT_RELEASE=MT `
-      -DLLVM_ENABLE_TERMINFO=OFF `
-      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install-debug `
+cmake -D CMAKE_GENERATOR_PLATFORM=x64 `
+      -D LLVM_TARGETS_TO_BUILD=X86 `
+      -D LLVM_ENABLE_RTTI=1 `
+      -D LLVM_USE_CRT_DEBUG=MTd `
+      -D LLVM_USE_CRT_RELEASE=MT `
+      -D LLVM_ENABLE_TERMINFO=OFF `
+      -D CMAKE_INSTALL_PREFIX=C:\LLVM\install-debug `
       C:\LLVM\src
 cmake --build . --config Debug
 cmake --build . --config Debug --target install

--- a/build-windows.html
+++ b/build-windows.html
@@ -26,9 +26,15 @@
                     <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
                 </a>
 
-                <section id="contact">
-                    For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-                </section>
+                <nav>
+                    <ul class="navbar">
+                        <li class="navbar"><a href="index.html">Overview</a></li>
+                        <li class="navbar active"><a href="index.html#build">Build</a></li>
+                        <li class="navbar"><a href="gallery.html">Gallery</a></li>
+                        <li class="navbar"><a href="perf.html">Performance</a></li>
+                        <li class="navbar" style="float:right"><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
             </header>
         </div>
 

--- a/build-windows.html
+++ b/build-windows.html
@@ -1,5 +1,4 @@
 
-
 <!DOCTYPE html>
 <html>
 
@@ -34,129 +33,223 @@
     <section id="main_content" class="inner">
 
       <h2>Windows Build Instructions</h2>
+
       <p>
-On Windows, OpenSWR is built using the scons package.
-Mesa windows build instructions are included
-<a href="http://www.mesa3d.org/install.html">here</a>.
+On Windows, OpenSWR is built using the SCons package as described in Mesa's
+<a href="http://www.mesa3d.org/install.html">installation page</a>.
 OpenSWR also requires LLVM versions greater than 3.9.0 to build.
+      </p>
 
       <p>
-The instructions below describe how to build Mesa with OpenSWR support
+The instructions below describe how to build Mesa with OpenSWR support for Windows.
+      </p>
 
-<h3>Download and Build LLVM</h3>
+                <ol class="toc">
+                    <li class="toc"><a href="#setup">Setup</a>
+                        <ol class="toc">
+                            <li class="toc"><a href="#building-llvm">Building and Installing LLVM</a></li>
+                        </ol>
+                    </li>
+                    <li class="toc"><a href="#building-openswr">Building Mesa with OpenSWR</a></li>
+                    <li class="toc"><a href="#using-openswr">Using Mesa with OpenSWR</a></li>
+                </ol>
 
-Follow these instructions if you don't have llvm built and installed
-in your system.
+                    <a name="setup"><h3>Setup</h3></a>
+
+                    <p>
+                    Mesa with OpenSWR requires the SCons package to build and install. SCons is available to download as
+                    an executable installer on SCons' <a href="https://scons.org/pages/download.html">download page</a>.
+                    The latest version should be fine.
+                    </p>
+
+                    <p>
+                    If you don't already have LLVM installed, you will need to install it first. LLVM requires CMake to
+                    build and install. CMake is available for Windows as an executable installer on CMake's <a
+                                                         href="https://cmake.org/download/">download page</a>.  The
+                                                     latest version should be fine.
+                    </p>
+
+                    <p>
+                    You will need a utility that can open and decompress <code>tar.gz</code> and/or <code>tar.xz</code>
+                    files. An easy-to-use (and free) graphical option for Windows is 7-zip, available on 7-zip's <a
+                                                         href="https://www.7-zip.org/download.html">download page</a>.
+                    </p>
+
+                    <a name="building-llvm"><h4>Build and Install LLVM</h4></a>
+
 <p>
-
+Mesa with OpenSWR relies on LLVM, so you will need to build and install it first if you do not already have it.
 Please refer to the LLVM Windows build instructions with Visual Studio
 for a general overview, located
-<a href="http://llvm.org/docs/GettingStartedVS.html">here</a>
+<a href="http://llvm.org/docs/GettingStartedVS.html">here</a>.
+</p>
 
 <p>
-  Use <strong>cmake</strong> to generate MSVC .sln files, as follows:
+Once downloaded and decompressed, create a build directory to contain the built LLVM distribution.
+In this example, we build both the release and debug version of LLVM, though you can choose to only have one or the
+other.
+</p>
+
+<p>
+Suppose we have LLVM extracted to <code>C:\LLVM\src</code> with build directories <code>C:\LLVM\build-release</code> and
+<code>C:\LLVM\build-debug</code>. We will install to <code>C:\LLVM\install-release</code> and
+<code>C:\LLVM\install-debug</code>, respectively.
+Use <code>cmake</code> to generate MSVC <code>.sln</code> files, as follows:
+</p>
 
 <pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_RTTI=1 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT -DLLVM_ENABLE_TERMINFO=OFF -DCMAKE_INSTALL_PREFIX=c:\my\llvm\root c:\my\llvm\src
-</code>
+cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
+      -DLLVM_TARGETS_TO_BUILD=X86 `
+      -DLLVM_ENABLE_RTTI=1 `
+      -DLLVM_USE_CRT_DEBUG=MTd `
+      -DLLVM_USE_CRT_RELEASE=MT `
+      -DLLVM_ENABLE_TERMINFO=OFF `
+      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install `
+      C:\LLVM\src
 </pre>
 
 <p>
-  Note that, in theory, you only need to use one of LLVM_USE_CRT_DEBUG
-  or LLVM_USE_CRT_RELEASE, depending on whether you are building Debug
+Note that, in theory, you only need to use one of <code>LLVM_USE_CRT_DEBUG</code>
+    or <code>LLVM_USE_CRT_RELEASE</code>, depending on whether you are building Debug
   or Release, but it doesn't hurt to always include both in the cmake line.
+</p>
 
 <p>
-  The mesa windows scons build has the peculiarity that you cannot
+  The Mesa Windows SCons build has the peculiarity that you cannot
   mix debug and release versions of libs (see link error LNK2038).
-  If you are planning of building both version of mesa,
+  If you are planning of building both version of Mesa,
   you should also build both versions of LLVM.
   Below, I am assuming that we are building both.
+</p>
 
 <p>
-  Build both flavors of LLVM using:
+  Build both flavors of LLVM as shown below. The release version:
+</p>
 
 <pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-cd c:\my\llvm\build-debug
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_RTTI=1 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT -DLLVM_ENABLE_TERMINFO=OFF -DCMAKE_INSTALL_PREFIX=c:\my\llvm\root-debug c:\my\llvm\src
-cmake --build . --config Debug
-cmake --build . --config Debug --target install
-
-cd c:\my\llvm\build-release
-cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_RTTI=1 -DLLVM_USE_CRT_DEBUG=MTd -DLLVM_USE_CRT_RELEASE=MT -DLLVM_ENABLE_TERMINFO=OFF -DCMAKE_INSTALL_PREFIX=c:\my\llvm\root-release c:\my\llvm\src
+cd C:\LLVM\build-release
+cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
+      -DLLVM_TARGETS_TO_BUILD=X86 `
+      -DLLVM_ENABLE_RTTI=1 `
+      -DLLVM_USE_CRT_DEBUG=MTd `
+      -DLLVM_USE_CRT_RELEASE=MT `
+      -DLLVM_ENABLE_TERMINFO=OFF `
+      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install-release `
+      C:\LLVM\src
 cmake --build . --config Release
 cmake --build . --config Release --target install
-</code>
 </pre>
 
 <p>
-  The results are located in the appopriate root directory.
-
-<h3>Build Mesa with OpenSWR</h3>
-
-First, clone the mesa repo.
-
-<p>
-  For debug builds:
+and the debug version:
+</p>
 
 <pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  set LLVM=c:\my\llvm\root-debug
-  scons swr=1 libgl-gdi
-</code>
+cd C:\LLVM\build-debug
+cmake -DCMAKE_GENERATOR_PLATFORM=x64 `
+      -DLLVM_TARGETS_TO_BUILD=X86 `
+      -DLLVM_ENABLE_RTTI=1 `
+      -DLLVM_USE_CRT_DEBUG=MTd `
+      -DLLVM_USE_CRT_RELEASE=MT `
+      -DLLVM_ENABLE_TERMINFO=OFF `
+      -DCMAKE_INSTALL_PREFIX=C:\LLVM\install-debug `
+      C:\LLVM\src
+cmake --build . --config Debug
+cmake --build . --config Debug --target install
 </pre>
 
+<a name="building-openswr"><h3>Build Mesa with OpenSWR</h3></a>
+
 <p>
-  For release builds:
-  
+First, clone the mesa repo. Full instructions are available on Mesa's <a
+   href="https://www.mesa3d.org/repository.html">repository page</a>. In this case, you can simply clone the read-only
+   repository.
+   </p>
+
+   <pre>
+   git clone git://anongit.freedesktop.org/git/mesa/mesa
+   </pre>
+
+<p>
+When building Mesa with OpenSWR, you must specify where LLVM is installed. In doing this, we can also specify which
+type of build we will do. For a debug Mesa build, link to the debug LLVM installation. Similarly, use a release LLVM for
+building release Mesa. For release builds:
 
 <pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
-  set LLVM=c:\my\llvm\root-release
+  set LLVM=C:\LLVM\install-release
   scons swr=1 libgl-gdi build=release
-</code>
+</pre>
+
+and for debug builds:
+
+<pre>
+  set LLVM=C:\LLVM\install-debug
+  scons swr=1 libgl-gdi
 </pre>
 
 <p>
   Note that you have to modify the LLVM environment variable between
   debug and release builds.
+</p>
 
 <p>
-  The build results in 3 .dll files:
-  <strong>opengl32.dll</strong>,
-  <strong>swrAVX.dll</strong> and
-  <strong>swrAVX2.dll</strong>.
-  <strong>opengl32.dll</strong> is located in
-  <strong>build\windows-x86_64\gallium\targets\libgl-gdi</strong>,
-  and the SWR libraries are located in
-  <strong>build\windows-x86_64\gallium\drivers\swr</strong>.
-  Place them either in <strong>c:\windows\system32</strong>
-  (making sure that you keep a backup of the original <strong>opengl32.dll</strong>),
-  or in your current directory (if you are running simple command-line tests).
-
-<p>
-  If you need to compile OSMesa on windows, just add <code>osmesa</code>
-  to the scons build line, as follows (example for release build):
+If you want to compile OSMesa (for off-screen rendering support), simply add <code>osmesa</code> to SCons. For example:
+</p>
 
 <pre>
-<code style=display:inline-table;background-color:MidnightBlue;color:yellow>
+  set LLVM=C:\LLVM\install-release
   scons swr=1 libgl-gdi osmesa build=release
-</code>
 </pre>
 
-The osmesa libraries will be found under the
-<strong>build\windows-x86_64\gallium\targets\osmesa</strong>
-directory.
+
+    <a name="using-openswr"><h3>Using Mesa with OpenSWR</h3></a>
 
 <p>
-  You'll have to set the <em>GALLIUM_DRIVER=swr</em> environment variable
-  for mesa to use the SWR driver.  If not specified, the default mesa
-  <em>llvmpipe</em> driver will be used.
+  The build results in three DLL files:
+  <ul>
+      <li><code>opengl32.dll</code></li>
+      <li><code>swrAVX.dll</code></li>
+      <li><code>swrAVX2.dll</code></li>
+  </ul>
+  <code>opengl32.dll</code> is located in
+  <code>build\windows-x86_64\gallium\targets\libgl-gdi</code>,
+  and the SWR libraries are located in
+  <code>build\windows-x86_64\gallium\drivers\swr</code>.
+  To make these libraries usable across the system, first make a backup of
+  <code>C:\Windows\system32\opengl32.dll</code>, then place the above DLLs in
+  <code>C:\Windows\system32</code>.
+  If you plan to just run simple command line tests, you can simply place them in your current directory.
+</p>
+
+  <p>
+If you built with OSMesa, the libraries will be found under the
+<code>build\windows-x86_64\gallium\targets\osmesa</code>
+directory. These can also be copied to 
+  <code>C:\Windows\system32</code>.
+  </p>
 
 <p>
-  Please modify your paths accordingly if you are running debug builds.
+To use Mesa with OpenSWR, you will need to set OpenSWR as the gallium driver to use with the <code>GALLIUM_DRIVER</code>
+environment variable:
+
+<pre>
+set GALLIUM_DRIVER=swr
+</pre>
+
+<p>
+Without this environmental variable set, the default Mesa <code>llvmpipe</code> driver will be used.
+</p>
+
+<p>
+When running with OpenSWR, you should see a message printed to the terminal stating that it found the appropriate
+architecture on your system:
+</p>
+
+<pre>
+SWR detected AVX2 instruction support (using: libswrAVX2.so).
+</pre>
+<br>
+
 
     <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">

--- a/contact.html
+++ b/contact.html
@@ -50,8 +50,13 @@
 
             <p>
             If you have problems running Mesa with OpenSWR, please use the
-            <a href="https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa">Mesa bug tracker on Bugzilla</a>. Please
-            be sure to specify Drivers/Gallium/swr as the component.
+            <a href="https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa">Mesa bug tracker on Bugzilla</a>.
+            Be sure to specify Drivers/Gallium/swr as the component.
+            </p>
+
+            <p>
+            Please note that OpenSWR primarily targets CPU-based rasterization for visualization purposes, not for
+            games. We suggest using other Mesa gallium drivers for games.
             </p>
         </section>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -30,8 +30,8 @@
                         <li class="navbar"><a href="index.html">Overview</a></li>
                         <li class="navbar"><a href="index.html#build">Build</a></li>
                         <li class="navbar"><a href="gallery.html">Gallery</a></li>
-                        <li class="navbar active"><a href="perf.html">Performance</a></li>
-                        <li class="navbar" style="float:right"><a href="contact.html">Contact</a></li>
+                        <li class="navbar"><a href="perf.html">Performance</a></li>
+                        <li class="navbar active" style="float:right"><a href="contact.html">Contact</a></li>
                     </ul>
                 </nav>
         </header>
@@ -41,36 +41,19 @@
     <div id="main_content_wrap" class="outer">
         <section id="main_content" class="inner">
             <h3><a id="intro" class="anchor" href="#wintro" aria-hidden="true"><span class="octicon octicon-link"></span></a>
-                Paraview and OpenSWR
+                OpenSWR Contact
             </h3>
 
-<p>Here is a case study of ParaView, comparing OpenSWR performance to that of
-the Mesa llvmpipe.</p>
+            <p>
+            To contact us, please send us an email at <a href="mailto:openswr@googlegroups.com">openswr@googlegroups.com</a>.
+            </p>
 
-<a href="jpg/OpenSWR_perf_vs_llvmpipe.png"><img src="jpg/OpenSWR_perf_vs_llvmpipe.png" width="95%"></a>
-
-<p> In the top graph, OpenSWR outperforms llvmpipe by 29x in a scene with 2.9
-million triangles and 51x when the geometry is increased to 106.2
-million triangles.  </p>
-
-<p> The bottom graph illustrates how OpenSWR performance scales with the number of
-cores used for rendering.  </p>
-
-System configuration:
-<ul>
-    <li>Intel<sup>&reg;</sup> Xeon<sup>&reg;</sup> E5-2699 v3 Processor, 2 x 18 cores, 2.3GHz
-    <li>ParaView 4.3.1 (unmodified, latest released version)</li>
-    <li>Mesa 10.5.1
-    <li>OpenSWR "alpha 2"
-    <li>TACC Isotropic turbulence data sets
-    <ul>
-        <li>Volumes ranging from 256<sup>3</sup> to 1280<sup>3</sup></li>
-        <li>Isosurface + slice extracted from each volume producing geometries 2.9M to 106.2M triangles</li>
-        <li>Model courtesy of the Texas Advanced Computing Center (TACC)
-    </ul>
-</ul>
-
-    </section>
+            <p>
+            If you have problems running Mesa with OpenSWR, please use the
+            <a href="https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa">Mesa bug tracker on Bugzilla</a>. Please
+            be sure to specify Drivers/Gallium/swr as the component.
+            </p>
+        </section>
     </div>
 
     <!-- FOOTER  -->

--- a/gallery.html
+++ b/gallery.html
@@ -25,9 +25,15 @@
                     <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
                 </a>
 
-            <section id="contact">
-				 For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-            </section>
+                <nav>
+                    <ul class="navbar">
+                        <li class="navbar"><a href="index.html">Overview</a></li>
+                        <li class="navbar"><a href="index.html#build">Build</a></li>
+                        <li class="navbar active"><a href="gallery.html">Gallery</a></li>
+                        <li class="navbar"><a href="perf.html">Performance</a></li>
+                        <li class="navbar" style="float:right"><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
         </header>
     </div>
 

--- a/gallery.html
+++ b/gallery.html
@@ -18,8 +18,12 @@
         <header class="inner">
           <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-          <h1 id="project_title">OpenSWR</h1>
-          <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <a href="index.html">
+                    <h1 id="project_title">OpenSWR</h1>
+                </a>
+                <a href="index.html">
+                    <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                </a>
 
             <section id="contact">
 				 For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.

--- a/index.html
+++ b/index.html
@@ -31,12 +31,12 @@
         <!-- MAIN CONTENT -->
         <div id="main_content_wrap" class="outer">
             <section id="main_content" class="inner">
-                <h3>
+                <h2>
                     <a id="intro" class="anchor" href="#wintro" aria-hidden="true">
                         <span class="octicon octicon-link"></span>
                     </a>
                     Overview
-                </h3>
+                </h2>
 
                 <p>
                     OpenSWR provides a high performance, highly scalable OpenGL-compatible software rasterizer that
@@ -70,93 +70,98 @@
                     presented at the Intel<sup>&reg;</sup> HPC Developers Conference at SC15.
                 </strong>
 
-                <hr>
-                <p>
-                <h5>
-                    How to build Mesa with OpenSWR:
-                </h5>
-                <br>
+                <h2>
+                    Building Mesa with OpenSWR
+                </h2>
                 Please follow instructions for <a href="build-linux.html">Linux</a> or <a href="build-windows.html">Windows</a>.
-                </p>
 
-                <hr>
-
-                <h3><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
+                <h2><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
                     Updates
-                </h3>
+                </h2>
 
                 <dl>
                     <dt>March 27, 2018</dt>
                     <dd>
-                    <a href="http://mesa3d.org/">Mesa 18.0.0</a> has been released with support for SKX and KNL architectures in OpenSWR.
+                        <a href="http://mesa3d.org/">Mesa 18.0.0</a> has been released with support for SKX and KNL
+                        architectures in OpenSWR.
                     </dd>
 
                     <dt>January 30, 2017</dt>
                     <dd>
-                    Added Windows build instructions, and moved instructions for both Linux and Windows to their own page.</p>
+                        Added Windows build instructions, and moved instructions for both Linux and Windows to their own
+                        page.
                     </dd>
 
                     <dt>July 8, 2016</dt>
                     <dd>
-                    <a href="http://mesa3d.org/">Mesa 12.0</a> has been released and contains OpenSWR as an optional driver.  Development work on OpenSWR is now done on the mesa git master repository.
+                        <a href="http://mesa3d.org/">Mesa 12.0</a> has been released and contains OpenSWR as an optional
+                        driver.  Development work on OpenSWR is now done on the mesa git master repository.
                     </dd>
 
                     <dt>Oct 19, 2015</dt>
                     <dd>
-                    Our initial public version of our Mesa+SWR integration work is now available from <a href="https://github.com/OpenSWR/openswr-mesa">https://github.com/OpenSWR/openswr-mesa</a>.
+                        Our initial public version of our Mesa+SWR integration work is now available from <a
+                        href="https://github.com/OpenSWR/openswr-mesa">https://github.com/OpenSWR/openswr-mesa</a>.
                     </dd>
 
                     <dt>Aug 9, 2015</dt>
                     <dd>
-                    Since the release of early alpha, we have been busy integrating our OpenSWR
-                    core into the Mesa project.  This enables us to take advantage of a very
-                    mature, very feature complete driver stack that would have been very difficult
-                    to develop on our own.
-                    The result is that OpenSWR now has far greater functionality than the OpenGL
-                    1.4 features available in the first alpha release.
+                        <p>
+                            Since the release of early alpha, we have been busy integrating our OpenSWR core into the
+                            Mesa project.  This enables us to take advantage of a very mature, very feature complete
+                            driver stack that would have been very difficult to develop on our own.
+                        </p>
+                        <p>
+                            The result is that OpenSWR now has far greater functionality than the OpenGL 1.4 features
+                            available in the first alpha release.
+                        </p>
                     </dd>
 
                     <dt>Dec 12, 2014</dt>
                     <dd>
-                    ALPHA release.  This version is the first to be released to the public.  Please bear
-                    with us if there are build or functionality issues.  The major
-                    applications used for testing were ParaView and VisIt - if you are
-                    trying another program you may encounter missing features.
-
-                    This version is coming out as we are working on some major cleanups to
-                    the code.  In order to keep our commitment to release this to the
-                    community and to provide a well-tested version, we are releasing the
-                    code that was used for the SC14 demonstrations.  The next major
-                    release will contain the cleanups.
-
-                    The source code can be downloaded from here:
-                    <ul>
-                        <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.tar.gz</a>
-                            <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.zip</a>
-                    </ul>
+                        <p>
+                            ALPHA release.  This version is the first to be released to the public.  Please bear with us
+                            if there are build or functionality issues.  The major applications used for testing were
+                            ParaView and VisIt - if you are trying another program you may encounter missing features.
+                        </p>
+                        <p>
+                            This version is coming out as we are working on some major cleanups to the code.  In order
+                            to keep our commitment to release this to the community and to provide a well-tested
+                            version, we are releasing the code that was used for the SC14 demonstrations.  The next
+                            major release will contain the cleanups.
+                        </p>
+                        <p>
+                            The source code can be downloaded here:
+                            <ul>
+                                <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.tar.gz</a>
+                                <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.zip</a>
+                            </ul>
+                        </p>
                     </dd>
 
                     <dt>Dec 8, 2014</dt>
                     <dd>
-                    The slides for our OpenSWR-related talks at SC14 are now available:
-                    <ul>
-                        <li>
-                            <a href="talks/SC14DevConf-SWR.pdf">"Software Rasterizer (SWR)"</a> (presented at the Intel HPC Developers Conference at SC14)
-                        </li>
-                        <li>
-                            <a href="http://www.ospray.org/download/talks/UltraVis14-HiFiVis-compressed.pdf">"High-Fidelity Visualization"</a> (presented at UltraVis 2014)
-                        </li>
-                    </ul>
+                        The slides for our OpenSWR-related talks at SC14 are now available:
+                        <ul>
+                            <li>
+                                <a href="talks/SC14DevConf-SWR.pdf">"Software Rasterizer (SWR)"</a> (presented at the
+                                Intel HPC Developers Conference at SC14)
+                            </li>
+                            <li>
+                                <a href="http://www.ospray.org/download/talks/UltraVis14-HiFiVis-compressed.pdf">
+                                    "High-Fidelity Visualization"</a> (presented at UltraVis 2014)
+                            </li>
+                        </ul>
                     </dd>
 
                     <dt>Nov 13, 2014</dt>
                     <dd>
-
-                    There is an upcoming talk on OpenSWR at Supercomputing 2014:
-                    <ul>
-                        <li>At the "Visualization" track of the <a href="http://ihpcc2014.com/dw-visual.html">Intel<sup>&reg;</sup> HPC Developer Conference (Nov 16, 2014)</a></li>
-                    </ul>
-                    We will be posting the slides of this talk as soon as the event is over.
+                        There is an upcoming talk on OpenSWR at Supercomputing 2014:
+                        <ul>
+                            <li>At the "Visualization" track of the <a href="http://ihpcc2014.com/dw-visual.html">
+                                    Intel<sup>&reg;</sup> HPC Developer Conference (Nov 16, 2014)</a></li>
+                        </ul>
+                        We will be posting the slides of this talk as soon as the event is over.
                     </dd>
                 </dl>
 

--- a/index.html
+++ b/index.html
@@ -18,8 +18,12 @@
             <header class="inner">
                 <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-                <h1 id="project_title">OpenSWR</h1>
-                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <a href="index.html">
+                    <h1 id="project_title">OpenSWR</h1>
+                </a>
+                <a href="index.html">
+                    <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                </a>
 
                 <section id="contact">
                     For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.

--- a/index.html
+++ b/index.html
@@ -94,8 +94,13 @@
                 </h2>
                 </a>
 
-                Build instructions are available for building on <a href="build-linux.html">Linux</a> or
-                <a href="build-windows.html">Windows</a>.
+                <p>
+                    OpenSWR is built as a gallium driver within Mesa.
+                </p>
+                <p>
+                    Build instructions are available for building on <a href="build-linux.html">Linux</a> or
+                    <a href="build-windows.html">Windows</a>.
+                </p>
 
                 <h2><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
                     Updates

--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
                 <h2>
                     Building Mesa with OpenSWR
                 </h2>
-                Please follow instructions for <a href="build-linux.html">Linux</a> or <a href="build-windows.html">Windows</a>.
+
+                Build instructions are available for building on <a href="build-linux.html">Linux</a> or
+                <a href="build-windows.html">Windows</a>.
 
                 <h2><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
                     Updates

--- a/index.html
+++ b/index.html
@@ -25,10 +25,21 @@
                     <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
                 </a>
 
+                <!--
                 <section id="contact">
                     For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
                 </section>
+                -->
 
+                <nav>
+                    <ul class="navbar">
+                        <li class="navbar active"><a href="index.html">Overview</a></li>
+                        <li class="navbar"><a href="#build">Build</a></li>
+                        <li class="navbar"><a href="gallery.html">Gallery</a></li>
+                        <li class="navbar"><a href="perf.html">Performance</a></li>
+                        <li class="navbar" style="float:right"><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
             </header>
         </div>
 
@@ -74,9 +85,14 @@
                     presented at the Intel<sup>&reg;</sup> HPC Developers Conference at SC15.
                 </strong>
 
+                <a name="build">
                 <h2>
+                    <a id="intro" class="anchor" href="#wintro" aria-hidden="true">
+                        <span class="octicon octicon-link"></span>
+                    </a>
                     Building Mesa with OpenSWR
                 </h2>
+                </a>
 
                 Build instructions are available for building on <a href="build-linux.html">Linux</a> or
                 <a href="build-windows.html">Windows</a>.

--- a/index.html
+++ b/index.html
@@ -1,172 +1,176 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
+    <head>
+        <meta charset='utf-8'>
+        <meta http-equiv="X-UA-Compatible" content="chrome=1">
+        <meta name="description" content="OpenSWR : A High Performance, Highly Scalable software OpenGL implementation">
 
-    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+        <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-    <title>OpenSWR</title>
-  </head>
+        <title>OpenSWR</title>
+    </head>
 
-  <body>
+    <body>
 
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-          <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
+        <!-- HEADER -->
+        <div id="header_wrap" class="outer">
+            <header class="inner">
+                <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-          <h1 id="project_title">OpenSWR</h1>
-          <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <h1 id="project_title">OpenSWR</h1>
+                <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
 
-            <section id="contact">
-                For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
-            </section>
+                <section id="contact">
+                    For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.
+                </section>
 
-        </header>
-    </div>
+            </header>
+        </div>
 
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-    <section id="main_content" class="inner">
-        <h3><a id="intro" class="anchor" href="#wintro" aria-hidden="true"><span class="octicon octicon-link"></span></a>
-            Overview
-        </h3>
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+            <section id="main_content" class="inner">
+                <h3>
+                    <a id="intro" class="anchor" href="#wintro" aria-hidden="true">
+                        <span class="octicon octicon-link"></span>
+                    </a>
+                    Overview
+                </h3>
 
-<p>OpenSWR provides a high performance, highly
-scalable OpenGL-compatible software rasterizer that allows use of
-unmodified visualization software.  This allows working with datasets
-when GPU hardware isn't available or is limiting.  OpenSWR is
-completely CPU-based, and runs on anything from laptops to
-workstations to compute nodes in HPC systems.</p>
+                <p>
+                    OpenSWR provides a high performance, highly scalable OpenGL-compatible software rasterizer that
+                    allows use of unmodified visualization software.  This allows working with datasets when GPU
+                    hardware isn't available or is limiting.  OpenSWR is completely CPU-based, and runs on anything from
+                    laptops to workstations to compute nodes in HPC systems.
+                </p>
 
-<p style="text-align:center"><a href="gallery.html"><img src="jpg/SpaceWeather_SWR.png" width="40%"></a>
-<a href="gallery.html"><img src="jpg/Wendell_SWR.png" width="40%"></a></p>
-<p style="text-align:center">Click either image for more information</p>
+                <p style="text-align:center"><a href="gallery.html"><img src="jpg/SpaceWeather_SWR.png" width="40%"></a>
+                <a href="gallery.html"><img src="jpg/Wendell_SWR.png" width="40%"></a></p>
+                <p style="text-align:center">Click either image for more information</p>
 
-<p>OpenSWR internally builds on top of LLVM, and fully utilizes modern
-instruction sets like 
-Intel<sup>&reg;</sup> Advanced Vector Extensions (AVX, AVX2, and AVX512) to achieve high
-rendering performance.  The charts below illustrate the compelling advantage of
-OpenSWR over Mesa llvmpipe in a real application scenario.</p>
+                <p>
+                    OpenSWR internally builds on top of LLVM, and fully utilizes modern instruction sets like
+                    Intel<sup>&reg;</sup> Advanced Vector Extensions (AVX, AVX2, and AVX512) to achieve high rendering
+                    performance.  The charts below illustrate the compelling advantage of OpenSWR over Mesa llvmpipe in
+                    a real application scenario.
+                </p>
 
-<p style="text-align:center"><a href="perf.html"><img src="jpg/OpenSWR_perf_vs_llvmpipe.png" width="40%"></a></p>
-<p style="text-align:center">Click for more information</p>
+                <p style="text-align:center"><a href="perf.html"><img src="jpg/OpenSWR_perf_vs_llvmpipe.png" width="40%"></a></p>
+                <p style="text-align:center">Click for more information</p>
 
-<p> OpenSWR is now fully integrated into Mesa and provides a SWR renderer that
-supports much of the OpenGL 3.3 Core and OpenGL 3.0 Compatibility contexts.  
-Standard Mesa environment variables provide the ability to run-time switch
-between OpenSWR and llvmpipe software renderers.</p>
+                <p>
+                    OpenSWR is now fully integrated into Mesa and provides a SWR renderer that supports much of the
+                    OpenGL 3.3 Core and OpenGL 3.0 Compatibility contexts.  Standard Mesa environment variables provide
+                    the ability to run-time switch between OpenSWR and llvmpipe software renderers.
+                </p>
 
-<strong>
-<p> For more detail, please see the <a href="talks/SC15DevConf-OpenSWR.pdf">"OpenSWR Overview"</a>
-presented at the Intel<sup>&reg;</sup> HPC Developers Conference at SC15.</p>
-</strong>
+                <strong>
+                    For more detail, please see the <a href="talks/SC15DevConf-OpenSWR.pdf">"OpenSWR Overview"</a>
+                    presented at the Intel<sup>&reg;</sup> HPC Developers Conference at SC15.
+                </strong>
 
-<hr>
-<p>
-<h5>
-How to build Mesa with OpenSWR:
-</h5>
-<br>
-Please follow instructions for <a href="build-linux.html">Linux</a> or <a href="build-windows.html">Windows</a>.
-</p>
+                <hr>
+                <p>
+                <h5>
+                    How to build Mesa with OpenSWR:
+                </h5>
+                <br>
+                Please follow instructions for <a href="build-linux.html">Linux</a> or <a href="build-windows.html">Windows</a>.
+                </p>
 
-<hr>
+                <hr>
 
-<h3><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
-    Updates
-</h3>
+                <h3><a id="news" class="anchor" href="#news" aria-hidden="true"><span class="octicon octicon-link"></span></a>
+                    Updates
+                </h3>
 
-<dl>
-  <dt>March 27, 2018</dt>
-  <dd>
-  <p><a href="http://mesa3d.org/">Mesa 18.0.0</a> has been released with support for SKX and KNL architectures in OpenSWR.
-  </dd>
+                <dl>
+                    <dt>March 27, 2018</dt>
+                    <dd>
+                    <a href="http://mesa3d.org/">Mesa 18.0.0</a> has been released with support for SKX and KNL architectures in OpenSWR.
+                    </dd>
 
-  <dt>January 30, 2017</dt>
-  <dd>
-    <p>Added Windows build instructions, and moved instructions for both Linux and Windows to their own page.</p>
-  </dd>
+                    <dt>January 30, 2017</dt>
+                    <dd>
+                    Added Windows build instructions, and moved instructions for both Linux and Windows to their own page.</p>
+                    </dd>
 
-  <dt>July 8, 2016</dt>
-  <dd>
-    <p><a href="http://mesa3d.org/">Mesa 12.0</a> has been released and contains OpenSWR as an optional driver.  Development work on OpenSWR is now done on the mesa git master repository.</p>
-  </dd>
+                    <dt>July 8, 2016</dt>
+                    <dd>
+                    <a href="http://mesa3d.org/">Mesa 12.0</a> has been released and contains OpenSWR as an optional driver.  Development work on OpenSWR is now done on the mesa git master repository.
+                    </dd>
 
-<dt>Oct 19, 2015</dt>
-<dd>
-<p>Our initial public version of our Mesa+SWR integration work is now available from <a href="https://github.com/OpenSWR/openswr-mesa">https://github.com/OpenSWR/openswr-mesa</a>.</p>
-</dd>
+                    <dt>Oct 19, 2015</dt>
+                    <dd>
+                    Our initial public version of our Mesa+SWR integration work is now available from <a href="https://github.com/OpenSWR/openswr-mesa">https://github.com/OpenSWR/openswr-mesa</a>.
+                    </dd>
 
-<dt>Aug 9, 2015</dt>
-<dd>
-<p> Since the release of early alpha, we have been busy integrating our OpenSWR
-core into the Mesa project.  This enables us to take advantage of a very
-mature, very feature complete driver stack that would have been very difficult
-to develop on our own.</p>
-<p> The result is that OpenSWR now has far greater functionality than the OpenGL
-1.4 features available in the first alpha release.</p>
-</dd>
+                    <dt>Aug 9, 2015</dt>
+                    <dd>
+                    Since the release of early alpha, we have been busy integrating our OpenSWR
+                    core into the Mesa project.  This enables us to take advantage of a very
+                    mature, very feature complete driver stack that would have been very difficult
+                    to develop on our own.
+                    The result is that OpenSWR now has far greater functionality than the OpenGL
+                    1.4 features available in the first alpha release.
+                    </dd>
 
-<dt>Dec 12, 2014</dt>
-<dd>
-<p>ALPHA release.  This version is the first to be released to the public.  Please bear
-with us if there are build or functionality issues.  The major
-applications used for testing were ParaView and VisIt - if you are
-trying another program you may encounter missing features.</p>
+                    <dt>Dec 12, 2014</dt>
+                    <dd>
+                    ALPHA release.  This version is the first to be released to the public.  Please bear
+                    with us if there are build or functionality issues.  The major
+                    applications used for testing were ParaView and VisIt - if you are
+                    trying another program you may encounter missing features.
 
-<p>This version is coming out as we are working on some major cleanups to
-the code.  In order to keep our commitment to release this to the
-community and to provide a well-tested version, we are releasing the
-code that was used for the SC14 demonstrations.  The next major
-release will contain the cleanups.</p>
+                    This version is coming out as we are working on some major cleanups to
+                    the code.  In order to keep our commitment to release this to the
+                    community and to provide a well-tested version, we are releasing the
+                    code that was used for the SC14 demonstrations.  The next major
+                    release will contain the cleanups.
 
-<p>The source code can be downloaded from here:
-<ul>
-<li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.tar.gz</a>
-<li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.zip</a>
-</ul>
-</p>
-</dd>
+                    The source code can be downloaded from here:
+                    <ul>
+                        <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.tar.gz</a>
+                            <li><a href="https://github.com/OpenSWR/openswr/archive/v0.1.tar.gz">v0.1.zip</a>
+                    </ul>
+                    </dd>
 
-<dt>Dec 8, 2014</dt>
-<dd>
-The slides for our OpenSWR-related talks at SC14 are now available:
-<ul>
-<li>
-<a href="talks/SC14DevConf-SWR.pdf">"Software Rasterizer (SWR)"</a> (presented at the Intel HPC Developers Conference at SC14)
-</li>
-<li>
-<a href="http://www.ospray.org/download/talks/UltraVis14-HiFiVis-compressed.pdf">"High-Fidelity Visualization"</a> (presented at UltraVis 2014)
-</li>
-</ul>
-</dd>
+                    <dt>Dec 8, 2014</dt>
+                    <dd>
+                    The slides for our OpenSWR-related talks at SC14 are now available:
+                    <ul>
+                        <li>
+                            <a href="talks/SC14DevConf-SWR.pdf">"Software Rasterizer (SWR)"</a> (presented at the Intel HPC Developers Conference at SC14)
+                        </li>
+                        <li>
+                            <a href="http://www.ospray.org/download/talks/UltraVis14-HiFiVis-compressed.pdf">"High-Fidelity Visualization"</a> (presented at UltraVis 2014)
+                        </li>
+                    </ul>
+                    </dd>
 
-<dt>Nov 13, 2014</dt>
-<dd>
+                    <dt>Nov 13, 2014</dt>
+                    <dd>
 
-There is an upcoming talk on OpenSWR at Supercomputing 2014:
-<ul>
-	<li>At the "Visualization" track of the <a href="http://ihpcc2014.com/dw-visual.html">Intel<sup>&reg;</sup> HPC Developer Conference (Nov 16, 2014)</a></li>
-</ul>
-We will be posting the slides of this talk as soon as the event is over.
-</dd>
-</dl>
+                    There is an upcoming talk on OpenSWR at Supercomputing 2014:
+                    <ul>
+                        <li>At the "Visualization" track of the <a href="http://ihpcc2014.com/dw-visual.html">Intel<sup>&reg;</sup> HPC Developer Conference (Nov 16, 2014)</a></li>
+                    </ul>
+                    We will be posting the slides of this talk as soon as the event is over.
+                    </dd>
+                </dl>
 
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
-		<br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
-		<br>&copy;2009-2018 Intel Corporation
-		<br><a href="https://www.intel.com/privacy">Privacy</a></p>
-      </footer>
-    </div>
+                <!-- FOOTER  -->
+                <div id="footer_wrap" class="outer">
+                    <footer class="inner">
+                        <p class="copyright">OpenSWR maintained by <a href="https://github.com/OpenSWR">OpenSWR</a>
+                        <br>For information about compiler optimizations, see our <a href="https://software.intel.com/en-us/articles/optimization-notice#opt-en">Optimization Notice</a>.
+                        <br>&copy;2009-2018 Intel Corporation
+                        <br><a href="https://www.intel.com/privacy">Privacy</a></p>
+                    </footer>
+                </div>
 
-    
 
-  </body>
+
+    </body>
 </html>

--- a/perf.html
+++ b/perf.html
@@ -18,8 +18,12 @@
         <header class="inner">
           <a id="mesa_banner" href="https://cgit.freedesktop.org/mesa/mesa/tree/src/gallium/drivers/swr">View source in Mesa</a>
 
-          <h1 id="project_title">OpenSWR</h1>
-          <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                <a href="index.html">
+                    <h1 id="project_title">OpenSWR</h1>
+                </a>
+                <a href="index.html">
+                    <h2 id="project_tagline">A High Performance, Highly Scalable Software Rasterizer for OpenGL</h2>
+                </a>
 
             <section id="contact">
                 For more information please <a href="mailto:openswr@googlegroups.com">send us an email</a>.

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -169,8 +169,8 @@ p img {
 
 pre, code {
   width: 100%;
-  color: #222;
-  background-color: #fff;
+  color: #444;
+  background-color: #f8f8f8;
 
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 14px;
@@ -218,6 +218,28 @@ ul {
 ol {
   list-style: decimal inside;
   padding-left: 20px;
+}
+
+ol.toc {
+    counter-reset: item;
+    margin: 0;
+    padding: 0;
+}
+ol.toc > li.toc {
+    display: table;
+    counter-increment: item;
+    margin-bottom: 0.3em;
+}
+ol.toc > li.toc:before {
+    content: counters(item, ".") ". ";
+    display: table-cell;
+    padding-right: 0.6em;
+}
+li.toc ol.toc > li.toc {
+    margin: 0;
+}
+li.toc ol.toc > li.toc:before {
+    content: counters(item, ".") " ";
 }
 
 dl dt {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -242,6 +242,30 @@ li.toc ol.toc > li.toc:before {
     content: counters(item, ".") " ";
 }
 
+ul.navbar {
+    border-top: 1px solid rgba(255,255,255,0.1);
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}
+li.navbar {
+    float: left;
+}
+li.navbar a {
+    display: block;
+    color: #ddd;
+    text-align: center;
+    text-decoration: none;
+    padding: 1em 1em;
+}
+li.navbar a:hover {
+    color: #fff;
+}
+li.navbar.active a {
+    color: #007edf;
+}
+
 dl dt {
   font-weight: bold;
 }


### PR DESCRIPTION
Main changes are clarifying the build instruction pages.

Other changes are to style:
- navigation bar
- using pre/code styling
- table of contents for build instructions
- split contact information into its own page